### PR TITLE
Build command to make static linked executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 build: deps
 	go build
 
+build-static: deps
+	CGO_ENABLED=0 GOARCH=amd64 go build -v -ldflags '-d -s -w' -o ./redis-exec
+
 deps:
 	go get gopkg.in/redis.v4
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ Execute commands based on redis pubsub or popping queues.
 
 test.sh (command) takes two arguments: queue and payload
 
+## build executable
+
+```
+make
+```
+
+## build executable static (copied from [gosu](https://github.com/tianon/gosu/blob/master/Dockerfile))
+
+```
+make build-static
+```
+
 ## WIP
 
 Just whipped this up real quick for something I need. I can clean it up later.


### PR DESCRIPTION
Small changes in the Makefile to allow the generation of a statically linked executable.

Also changes in README.md explaining how to create the executable.